### PR TITLE
add some new tests

### DIFF
--- a/zuds/tests/conftest.py
+++ b/zuds/tests/conftest.py
@@ -8,6 +8,7 @@ from zuds.tests.fixtures import (ScienceImageFactory,
                                  TriangulumScienceImageFactory,
                                  SourceFactory,
                                  TMP_DIR)
+import pdb
 import uuid
 import zuds
 import shutil
@@ -43,6 +44,9 @@ zuds.create_tables()
 def _get_mask(url):
     r = requests.get(url)
     outname = pathlib.Path(TMP_DIR) / url.split('/')[-1]
+    outname = str(outname.absolute()).replace(
+        '.fits', f'.{uuid.uuid4().hex}.fits'
+    )
     with open(outname, 'wb') as f:
         f.write(r.content)
 
@@ -52,10 +56,15 @@ def _get_mask(url):
 def _get_sci(url, mask):
     r = requests.get(url)
     outname = pathlib.Path(TMP_DIR) / url.split('/')[-1]
+    outname = str(outname.absolute()).replace(
+        '.fits', f'.{uuid.uuid4().hex}.fits'
+    )
+    mskpath = mask.local_path
     with open(outname, 'wb') as f:
         f.write(r.content)
     s = zuds.ScienceImage.from_file(outname, load_others=False)
     s.mask_image = mask
+    mask.map_to_local_file(mskpath)
     return s
 
 

--- a/zuds/tests/suite/test_stack.py
+++ b/zuds/tests/suite/test_stack.py
@@ -1,0 +1,36 @@
+import os
+import zuds
+import uuid
+import numpy as np
+
+stampcent = np.array([[153.38206, 148.80536, 147.25192, 153.63702, 152.90718, 150.19846],
+                      [149.69249, 154.14828, 148.3748 , 153.9903 , 151.28311, 154.92308],
+                      [154.71527, 141.91301, 147.02524, 151.24019, 148.31198, 147.89133],
+                      [147.88127, 151.21399, 152.23627, 145.1139 , 149.66772, 151.06998],
+                      [144.1585 , 150.05353, 154.60002, 152.49254, 144.95595, 147.17065],
+                      [155.59914, 146.6712 , 143.15219, 156.93697, 150.05168, 150.3548 ]])
+
+
+def test_stack(sci_image_data_20200531, sci_image_data_20200601):
+    images = [sci_image_data_20200531, sci_image_data_20200601]
+    outdir = os.path.dirname(images[0].local_path)
+    outname = os.path.join(outdir, f'{uuid.uuid4().hex}.fits')
+    stack = zuds.ReferenceImage.from_images(images, outname)
+    naxis1, naxis2 = stack.header['NAXIS1'], stack.header['NAXIS2']
+    stamp = stack.data[naxis1 // 2 - 3:naxis1 // 2 + 3,
+                       naxis2 // 2 - 3:naxis2 // 2 + 3]
+    assert naxis1 == 544
+    assert naxis2 == 545
+    np.testing.assert_allclose(stamp, stampcent)
+
+
+def test_stack_input_images(sci_image_data_20200531, sci_image_data_20200601):
+    images = [sci_image_data_20200531, sci_image_data_20200601]
+    outdir = os.path.dirname(images[0].local_path)
+    outname = os.path.join(outdir, f'{uuid.uuid4().hex}.fits')
+    stack = zuds.ReferenceImage.from_images(images, outname)
+    zuds.DBSession().add(stack)
+    zuds.DBSession().commit()
+    assert len(stack.input_images) == 2
+    assert sci_image_data_20200601 in stack.input_images
+    assert sci_image_data_20200531 in stack.input_images


### PR DESCRIPTION
This PR makes the `fixture`s that generate `Image`s in `conftest.py` factories assign different basenames (randomly) to the images each time they are called. This avoids database collisions and increases reproducibility in testing when the tests are run in a different order. 

It also adds some new tests to check the math of stacking. 
