### PR TITLE
enable anonymous subtractions

### DIFF
--- a/zuds/subtraction.py
+++ b/zuds/subtraction.py
@@ -8,7 +8,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship
 
-from .core import DBSession
+from .core import DBSession, Base
 from .fitsfile import HasWCS
 from .image import (CalibratableImageBase, ScienceImage, CalibratableImage,
                     FITSImage, CalibratedImage)
@@ -190,15 +190,16 @@ class Subtraction(HasWCS):
         sub._rmsimg = FITSImage.from_file(final_out.replace('.fits',
                                                             '.rms.fits'))
 
-        sub.header['FIELD'] = sub.field = sci.field
-        sub.header['CCDID'] = sub.ccdid = sci.ccdid
-        sub.header['QID'] = sub.qid = sci.qid
-        sub.header['FID'] = sub.fid = sci.fid
+        if isinstance(sub, Base):
+            sub.header['FIELD'] = sub.field = sci.field
+            sub.header['CCDID'] = sub.ccdid = sci.ccdid
+            sub.header['QID'] = sub.qid = sci.qid
+            sub.header['FID'] = sub.fid = sci.fid
 
-        finalsubmask.header['FIELD'] = finalsubmask.field = sci.field
-        finalsubmask.header['CCDID'] = finalsubmask.ccdid = sci.ccdid
-        finalsubmask.header['QID'] = finalsubmask.qid = sci.qid
-        finalsubmask.header['FID'] = finalsubmask.fid = sci.fid
+            finalsubmask.header['FIELD'] = finalsubmask.field = sci.field
+            finalsubmask.header['CCDID'] = finalsubmask.ccdid = sci.ccdid
+            finalsubmask.header['QID'] = finalsubmask.qid = sci.qid
+            finalsubmask.header['FID'] = finalsubmask.fid = sci.fid
 
         sub.mask_image = finalsubmask
         finalsubmask.parent_image = sub

--- a/zuds/subtraction.py
+++ b/zuds/subtraction.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship
 
 from .core import DBSession, Base
-from .fitsfile import HasWCS
 from .image import (CalibratableImageBase, ScienceImage, CalibratableImage,
                     FITSImage, CalibratedImage)
 from .mask import MaskImageBase, MaskImage
@@ -37,7 +36,7 @@ def sub_name(frame, template):
     return sub
 
 
-class Subtraction(HasWCS):
+class Subtraction(CalibratableImageBase):
 
     @declared_attr
     def reference_image_id(self):

--- a/zuds/subtraction.py
+++ b/zuds/subtraction.py
@@ -183,8 +183,10 @@ class Subtraction(CalibratableImageBase):
 
         # now read the final output products into database mapped records
         sub = cls.from_file(final_out, load_others=False)
-        finalsubmask = MaskImage.from_file(final_out.replace('.fits',
-                                                             '.mask.fits'))
+
+        finalmaskclass = MaskImage if isinstance(sub, Base) else MaskImageBase
+        finalsubmask = finalmaskclass.from_file(final_out.replace('.fits',
+                                                                  '.mask.fits'))
 
         sub._rmsimg = FITSImage.from_file(final_out.replace('.fits',
                                                             '.rms.fits'))

--- a/zuds/tests/conftest.py
+++ b/zuds/tests/conftest.py
@@ -106,6 +106,14 @@ def refimg_data_first2_imgs(sci_image_data_20200531, sci_image_data_20200601):
 
 
 @pytest.fixture
+def refimg_data_last2_imgs(sci_image_data_20200601, sci_image_data_20200604):
+    imgs = [sci_image_data_20200601, sci_image_data_20200604]
+    out = os.path.join(TMP_DIR, f'ref-{uuid.uuid4().hex}.fits')
+    ref = zuds.ReferenceImage.from_images(imgs, out)
+    return ref
+
+
+@pytest.fixture
 def science_image():
     return ScienceImageFactory(basename=uuid.uuid4().hex)
 

--- a/zuds/tests/suite/test_sub.py
+++ b/zuds/tests/suite/test_sub.py
@@ -32,3 +32,9 @@ def test_sub(sci_image_data_20200604, refimg_data_first2_imgs):
     np.testing.assert_allclose(stamp, stampcent)
     assert sub.reference_image is refimg_data_first2_imgs
     assert sub.target_image is sci_image_data_20200604
+
+
+def test_anonymous_sub(refimg_data_first2_imgs, refimg_data_last2_imgs):
+    sub = zuds.Subtraction.from_images(
+        refimg_data_first2_imgs, refimg_data_last2_imgs
+    )


### PR DESCRIPTION
Add the ability to generate non-DB mapped subtractions that can operate on arbitrary target and reference `CalibratableImageBase`s. 